### PR TITLE
Add std::fmt::Debug impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ More introduction is in the README.
 #![doc(html_root_url = "https://docs.rs/oom/0.3.0")]
 #![warn(rust_2018_idioms)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[cfg(feature = "slice")]
 mod slice;
 #[cfg(feature = "vec")]

--- a/src/slice/share.rs
+++ b/src/slice/share.rs
@@ -3,6 +3,8 @@ use core::hint::unreachable_unchecked;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
 use core::slice;
+#[cfg(feature = "std")]
+use std::fmt;
 
 // FIXME: Use unsized `[T]` as inner type (see loaf crate)
 // and return `&NonEmptySlice` or `&mut NonEmptySlice`.
@@ -55,6 +57,13 @@ const _BUILTIN_TRAITS: () = {
     impl<'a, T> AsRef<[T]> for NonEmptySlice<'a, T> {
         fn as_ref(&self) -> &[T] {
             self.as_slice()
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl<'a, T: fmt::Debug> fmt::Debug for NonEmptySlice<'a, T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+            fmt::Debug::fmt(self.as_slice(), f)
         }
     }
 };

--- a/src/slice/unique.rs
+++ b/src/slice/unique.rs
@@ -3,6 +3,8 @@ use core::hint::unreachable_unchecked;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
 use core::slice;
+#[cfg(feature = "std")]
+use std::fmt;
 
 /// A non-empty mutable slice type, counterpart of `&mut [T]`.
 pub struct NonEmptyMutSlice<'a, T: Sized> {
@@ -43,6 +45,13 @@ const _BUILTIN_TRAITS: () = {
     impl<'a, T> AsRef<[T]> for NonEmptyMutSlice<'a, T> {
         fn as_ref(&self) -> &[T] {
             self.as_slice()
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl<'a, T: fmt::Debug> fmt::Debug for NonEmptyMutSlice<'a, T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+            fmt::Debug::fmt(self.as_slice(), f)
         }
     }
 };

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -5,6 +5,8 @@ use core::cmp::Ordering;
 use core::hint::unreachable_unchecked;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
+#[cfg(feature = "std")]
+use std::fmt;
 
 use crate::{NonEmptyMutSlice, NonEmptySlice};
 
@@ -53,6 +55,13 @@ const _BUILTIN_TRAITS: () = {
     impl<T> AsRef<[T]> for NonEmptyVec<T> {
         fn as_ref(&self) -> &[T] {
             self.as_slice()
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl<T: fmt::Debug> fmt::Debug for NonEmptyVec<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+            fmt::Debug::fmt(self.as_slice(), f)
         }
     }
 };


### PR DESCRIPTION
I wasn't sure whether to put the `impl`s in the `const _BUILTIN_TRAITS` constants, since I don't really know what they are for. On the one hand, all the trait implementations go in there, but on the other, `std::fmt::Debug` isn't a builtin.

Let me know if they're in the wrong place and I'll fixup.